### PR TITLE
Set up Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Dependabot configuration for puria-radmard/emaildrafter
+#
+# Configuration options documented at:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+      time: "06:00"


### PR DESCRIPTION
Dependabot is a GitHub service that checks for updates to our dependencies (in requirements.txt) and creates pull requests to update the pinned version whenever an update is available.

For now it'll be making pull requests against master, although we should probably make it PR against a staging branch (to test that dependency updates don't break things) in the future.