### PR TITLE
Hotfix: don't mix uri and self.uri badly

### DIFF
--- a/database.py
+++ b/database.py
@@ -37,14 +37,15 @@ class myDb:
     db_name = None
 
     def __init__(self, uri=None):
-        if self.uri is None:
+        if uri is None:
             load_dotenv()
-            self.uri = os.getenv("MONGODB_URI")
-        if not self.uri:
+            uri = os.getenv("MONGODB_URI")
+        if not uri:
             raise ValueError(
                 "MongoDB URI not provided to constructor nor specified in MONGODB_URI envvar"
             )
-        self.client = pymongo.MongoClient(uri)
+        self.uri = uri
+        self.client = pymongo.MongoClient(self.uri)
         self.db_name = re.findall("heroku_[a-z|1-9]*", self.uri)[0]
 
     def get_db_uri(self):


### PR DESCRIPTION
If `uri` is None then `self.uri` is derived from envvar `MONGODB_URI`, but local variable `uri` (still None) is used to create the MongoDB client.

TODO: eliminate use of `self.uri` and possibly `self.db_name` (or make them properties).  Have a single source of truth in `self.client.uri`.

This is an extension to #29.